### PR TITLE
More improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,6 @@
 # Changelog
+## Version 1.3 (2025-02-20)
+* Add changes made to the undo stack, esp. needed for Mu4
 ## Version 1.2 (2025-02-17)
 * Porting to Mu4, maintaining full compatibility with Mu3
 ## Version 1.1 (2022-11-26)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 ## Version 1.3 (2025-02-20)
 * Add changes made to the undo stack, esp. needed for Mu4
 * Work on all staves and voices
+* Add a version for German curly quotes
 ## Version 1.2 (2025-02-17)
 * Porting to MuseScore 4, maintaining full compatibility with MuseScore 3
 ## Version 1.1 (2022-11-26)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 ## Version 1.3 (2025-02-20)
 * Add changes made to the undo stack, esp. needed for Mu4
 * Work on all staves and voices
+* Add a version for German curly quotes
 ## Version 1.2 (2025-02-17)
 * Porting to Mu4, maintaining full compatibility with Mu3
 ## Version 1.1 (2022-11-26)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,10 @@
 # Changelog
 ## Version 1.3 (2025-02-20)
-* Add changes made to the undo stack, esp. needed for Mu4
-* Work on all staves and voices
-* Add a version for German curly quotes
+* Add changes made to the undo stack (especially needed for MuseScore 4).
+* Works on all staves and voices.
+* Add a version for German curly quotes.
 ## Version 1.2 (2025-02-17)
-* Porting to Mu4, maintaining full compatibility with Mu3
+* Ported to MuseScore 4, maintaining full compatibility with MuseScore 3
 ## Version 1.1 (2022-11-26)
 * Added support for curly quotes in other text surrounding the staff, such as System Text, Staff Text, Expression Text, Rehearsal mark, Instrument Change, and Tempo Markings. 
 ## Version 1.0 (2022-11-25)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,6 @@
 # Changelog
+## Version 1.3 (2025-02-20)
+* Add changes made to the undo stack, esp. needed for Mu4
 ## Version 1.2 (2025-02-17)
 * Porting to MuseScore 4, maintaining full compatibility with MuseScore 3
 ## Version 1.1 (2022-11-26)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 ## Version 1.3 (2025-02-20)
 * Add changes made to the undo stack, esp. needed for Mu4
+* Work on all staves and voices
 ## Version 1.2 (2025-02-17)
 * Porting to Mu4, maintaining full compatibility with Mu3
 ## Version 1.1 (2022-11-26)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 ## Version 1.3 (2025-02-20)
 * Add changes made to the undo stack, esp. needed for Mu4
+* Work on all staves and voices
 ## Version 1.2 (2025-02-17)
 * Porting to MuseScore 4, maintaining full compatibility with MuseScore 3
 ## Version 1.1 (2022-11-26)

--- a/README.md
+++ b/README.md
@@ -4,7 +4,8 @@
 ## Usage
 1. Copy curlyQuotes.qml and/or curlyQuotes-German.qml into your plugins directory. See [MuseScore 3 documentation](https://musescore.org/en/handbook/3/plugins#install-new)resp. [MuseScore 4 documentation](https://musescore.org/en/handbook/4/plugins#manage) for details.
 2. Enable the plugin in MuseScore (**Plugins** > **Plugin Manager**).
-3. Choose **Plugins** > **Curly Quotes** to convert existing lyrics and other text surround the staff. 
+3. Optionally select the range the plugin should work on, else it'll work on the entire score. 
+4. Choose **Plugins** > **Curly Quotes** to convert existing lyrics and other text surround the staff. 
 
 ## Features
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 **Curly Quotes** is a MuseScore 3.x/4.x plugin to change apostrophes and quotation marks from straight to curly (also known as “**smart quotes**”). The plugin changes quotation marks in lyrics and other text surrounding the staff (like staff text, system text, expression text, etc.)
 
 ## Usage
-1. Copy curlyQuotes.qml and/or curlyQuotes-German.qml into your plugins directory. See [MuseScore 3 documentation](https://musescore.org/en/handbook/3/plugins#install-new)resp. [MuseScore 4 documentation](https://musescore.org/en/handbook/4/plugins#manage) for details.
+1. Copy curlyQuotes.qml and/or curlyQuotes-German.qml into your plugins directory. See [MuseScore 4 documentation](https://musescore.org/en/handbook/4/plugins#manage) or [MuseScore 3 documentation](https://musescore.org/en/handbook/3/plugins#install-new) for details.
 2. Enable the plugin(s) in MuseScore (**Plugins** > **Plugin Manager**).
 3. Optionally select the range the plugin should work on, else it'll work on the entire score. 
 4. Choose **Plugins** > **Curly Quotes** resp. **Curly Quotes - German** to convert existing lyrics and other text surrounding the staff. 
@@ -32,7 +32,7 @@ These rules work most of the time, but fail in two circumstances.
 1. Contractions like **’neath** and **’tis** should use a normal apostrophe (“right single quote”). 
 2. When you have a quotation mark followed by another quotation mark. For instance, nested quotes like, “‘Hi,’ he told me.”
 
-To address the first issue, the Curly Quotes plugin keeps a list of English words that start with an apostrophe (see line 12). When it encounters these words, it adopts the “right single quote” character. These types of contractions are more common in lyrics than other types of writing. 
+To address the first issue, the Curly Quotes plugin keeps a list of English words that start with an apostrophe (see line 22). When it encounters these words, it adopts the “right single quote” character. These types of contractions are more common in lyrics than other types of writing. 
 
 To address the second issue, the Curly Quotes plugin adapts the second rule: 
 * If the quotation mark follows a space _or another quotation mark_, use a left quote. 

--- a/README.md
+++ b/README.md
@@ -2,9 +2,10 @@
 **Curly Quotes** is a MuseScore 3.x/4.x plugin to change apostrophes and quotation marks from straight to curly (also known as “**smart quotes**”). The plugin changes quotation marks in lyrics and other text surrounding the staff (like staff text, system text, expression text, etc.)
 
 ## Usage
+1. Copy curlyQuotes.qml into your plugins directory. See [MuseScore 3 documentation](https://musescore.org/en/handbook/3/plugins#install-new)resp. [MuseScore 4 documentation](https://musescore.org/en/handbook/4/plugins#manage) for details.
 2. Enable the plugin in MuseScore (**Plugins** > **Plugin Manager**).
-3. Choose **Plugins** > **Curly Quotes** to convert existing lyrics and other text surround the staff. 
-1. Copy curlyQuotes.qml and/or curlyQuotes-German.qml into your plugins directory. See [MuseScore 3 documentation](https://musescore.org/en/handbook/3/plugins#install-new)resp. [MuseScore 4 documentation](https://musescore.org/en/handbook/4/plugins#manage) for details.
+3. Optionally select the range the plugin should work on, else it'll work on the entire score. 
+4. Choose **Plugins** > **Curly Quotes** to convert existing lyrics and other text surround the staff. 
 
 ## Features
 

--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
 # Curly Quotes
-**Curly Quotes** is a MuseScore 3.x plugin to change apostrophes and quotation marks from straight to curly (also known as “**smart quotes**”). The plugin changes quotation marks in lyrics and other text surrounding the staff (like staff text, system text, expression text, etc.)
+**Curly Quotes** is a MuseScore 3.x/4.x plugin to change apostrophes and quotation marks from straight to curly (also known as “**smart quotes**”). The plugin changes quotation marks in lyrics and other text surrounding the staff (like staff text, system text, expression text, etc.)
 
 ## Usage
-1. Copy curlyQuotes.qml into your plugins directory. See [MuseScore documentation](https://musescore.org/en/handbook/3/plugins#installation) for details.
 2. Enable the plugin in MuseScore (**Plugins** > **Plugin Manager**).
 3. Choose **Plugins** > **Curly Quotes** to convert existing lyrics and other text surround the staff. 
+1. Copy curlyQuotes.qml and/or curlyQuotes-German.qml into your plugins directory. See [MuseScore 3 documentation](https://musescore.org/en/handbook/3/plugins#install-new)resp. [MuseScore 4 documentation](https://musescore.org/en/handbook/4/plugins#manage) for details.
 
 ## Features
 

--- a/README.md
+++ b/README.md
@@ -2,10 +2,10 @@
 **Curly Quotes** is a MuseScore 3.x/4.x plugin to change apostrophes and quotation marks from straight to curly (also known as “**smart quotes**”). The plugin changes quotation marks in lyrics and other text surrounding the staff (like staff text, system text, expression text, etc.)
 
 ## Usage
-1. Copy curlyQuotes.qml into your plugins directory. See [MuseScore 3 documentation](https://musescore.org/en/handbook/3/plugins#install-new)resp. [MuseScore 4 documentation](https://musescore.org/en/handbook/4/plugins#manage) for details.
-2. Enable the plugin in MuseScore (**Plugins** > **Plugin Manager**).
+1. Copy curlyQuotes.qml and/or curlyQuotes-German.qml into your plugins directory. See [MuseScore 3 documentation](https://musescore.org/en/handbook/3/plugins#install-new)resp. [MuseScore 4 documentation](https://musescore.org/en/handbook/4/plugins#manage) for details.
+2. Enable the plugin(s) in MuseScore (**Plugins** > **Plugin Manager**).
 3. Optionally select the range the plugin should work on, else it'll work on the entire score. 
-4. Choose **Plugins** > **Curly Quotes** to convert existing lyrics and other text surround the staff. 
+4. Choose **Plugins** > **Curly Quotes** resp. **Curly Quotes - German** to convert existing lyrics and other text surrounding the staff. 
 
 ## Features
 

--- a/README.md
+++ b/README.md
@@ -3,9 +3,9 @@
 
 ## Usage
 1. Copy curlyQuotes.qml and/or curlyQuotes-German.qml into your plugins directory. See [MuseScore 3 documentation](https://musescore.org/en/handbook/3/plugins#install-new)resp. [MuseScore 4 documentation](https://musescore.org/en/handbook/4/plugins#manage) for details.
-2. Enable the plugin in MuseScore (**Plugins** > **Plugin Manager**).
+2. Enable the plugin(s) in MuseScore (**Plugins** > **Plugin Manager**).
 3. Optionally select the range the plugin should work on, else it'll work on the entire score. 
-4. Choose **Plugins** > **Curly Quotes** to convert existing lyrics and other text surround the staff. 
+4. Choose **Plugins** > **Curly Quotes** resp. **Curly Quotes - German** to convert existing lyrics and other text surrounding the staff. 
 
 ## Features
 

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # Curly Quotes
-**Curly Quotes** is a MuseScore plugin to change apostrophes and quotation marks from straight to curly (also known as “**smart quotes**”). The plugin changes quotation marks in lyrics and other text surrounding the staff (like staff text, system text, expression text, etc.)
+**Curly Quotes** is a MuseScore 3.x/4.x plugin to change apostrophes and quotation marks from straight to curly (also known as “**smart quotes**”). The plugin changes quotation marks in lyrics and other text surrounding the staff (like staff text, system text, expression text, etc.)
 
 ## Usage
-1. Copy curlyQuotes.qml into your plugins directory. See [MuseScore documentation](https://musescore.org/en/handbook/4/plugins#manage) for details.
+1. Copy curlyQuotes.qml and/or curlyQuotes-German.qml into your plugins directory. See [MuseScore 3 documentation](https://musescore.org/en/handbook/3/plugins#install-new)resp. [MuseScore 4 documentation](https://musescore.org/en/handbook/4/plugins#manage) for details.
 2. Enable the plugin in MuseScore (**Plugins** > **Plugin Manager**).
 3. Choose **Plugins** > **Curly Quotes** to convert existing lyrics and other text surround the staff. 
 

--- a/curlyQuotes-German.qml
+++ b/curlyQuotes-German.qml
@@ -2,14 +2,14 @@ import QtQuick 2.9
 import MuseScore 3.0
 
 MuseScore {
-  property variant language : "" //qsTr(" - German")
+  property variant language : qsTr(" - German")
   menuPath: "Plugins." + qsTr("Curly Quotes") + language 
   description: "Change apostrophes and double quotes from straight to curly. This plugin affects lyrics text, system text, staff text, expression text, rehearsal marks, instrument changes, and tempo markings."
   version: "1.3"
 
   id: curlyquotes
 
-  //4.4 title: "Curly Quotes"
+  //4.4 title: "Curly Quotes - German"
   Component.onCompleted : {
     if (mscoreMajorVersion >= 4 && mscoreMinorVersion <= 3) {
        curlyquotes.title = "Curly Quotes" + language;

--- a/curlyQuotes-German.qml
+++ b/curlyQuotes-German.qml
@@ -2,14 +2,14 @@ import QtQuick 2.9
 import MuseScore 3.0
 
 MuseScore {
-  property variant language : "" //qsTr(" - German")
+  property variant language : qsTr(" - German")
   menuPath: "Plugins." + qsTr("Curly Quotes") + language 
   description: "Change apostrophes and double quotes from straight to curly. This plugin affects lyrics text, system text, staff text, expression text, rehearsal marks, instrument changes, and tempo markings."
   version: "1.3"
 
   id: curlyquotes
 
-  //4.4 title: "Curly Quotes" + language
+  //4.4 title: "Curly Quotes - German" // + language doesn't work here
   Component.onCompleted : {
     if (mscoreMajorVersion >= 4 && mscoreMinorVersion <= 3) {
        curlyquotes.title = "Curly Quotes" + language;

--- a/curlyQuotes.qml
+++ b/curlyQuotes.qml
@@ -2,99 +2,116 @@ import QtQuick 2.9
 import MuseScore 3.0
 
 MuseScore {
-  menuPath: "Plugins." + qsTr("Curly Quotes")
+  menuPath: "Plugins." + qsTr("Curly Quotes") + language 
   description: "Change apostrophes and double quotes from straight to curly. This plugin affects lyrics text, system text, staff text, expression text, rehearsal marks, instrument changes, and tempo markings."
   version: "1.3"
 
   id: curlyquotes
- 
+
   //4.4 title: "Curly Quotes"
   Component.onCompleted : {
     if (mscoreMajorVersion >= 4 && mscoreMinorVersion <= 3) {
-       curlyquotes.title = "Curly Quotes";
+       curlyquotes.title = "Curly Quotes" + language;
     }
+  }
+
+  property variant wordsStartingWithApostrophe : ["'bout","'cause","'cept","'em","'fro","'n","'neath","'nother","'pon","'re","'round","'s","'sall","'scuse","'sfar","'sup","'thout","'til","'tis","'twas","'tween","'twere","'ve"]
+
+  function changeQuotes(text, type) {
+    var t = text;
+    // Left single quote (exclude words that start with apostrophe)
+    if (type <= 1 // lyrics SINGLE or BEGIN syllable, not END or MIDDLE
+        && WordsStartingWithApostrophe.indexOf(t.replace("&quot;", '"').replace(/[,.?¿!¡;:"‘’“”‚„‹›«»–— *†‡()\[\]{}\/`]/g, "").replace(/'$/, "")) == -1) { // exclude common contractions that starts with an apostrophe (omit punctuation when checking against word list)
+      t = t.replace(/^'/g,"‘");
+      t = t.replace(/(\s|\s&quot;)'/g, "$1‘");
+      t = t.replace(/^&quot;'|^“'/g, "“‘");
+      }
+
+    // Right single quote or normal apostrophe
+    t = t.replace(/'/g, "’");
+
+    // Left double quote
+    t = t.replace(/^&quot;/g, "“");
+    t = t.replace(/(\s‘?)&quot;/g, "$1“");
+    t = t.replace(/^'&quot;|^‘&quot;/g, "‘“");
+
+    // Right double quote
+    t = t.replace(/&quot;/g, "”");
+
+    return t;
   }
 
   onRun: {
     if (!curScore)
       (typeof(quit) === 'undefined' ? Qt.quit : quit)()
 
-    var wordsStartingWithApostrophe = ["'bout","'cause","'cept","'em","'fro","'n","'neath","'nother","'pon","'re","'round","'s","'sall","'scuse","'sfar","'sup","'thout","'til","'tis","'twas","'tween","'twere","'ve"]
-    
     var cursor = curScore.newCursor();
-    cursor.voice    = 0;
-    cursor.staffIdx = 0;
-    cursor.rewind(Cursor.SCORE_START);
-
+    cursor.rewind(Cursor.SELECTION_START)
+    var startStaff
+    var endStaff
+    var endTick
+    var fullScore = false
+    if (!cursor.segment) { // no selection
+      fullScore = true
+      startStaff = 0 // start with 1st staff
+      endStaff = curScore.nstaves - 1 // and end with last
+    }
+    else {
+      startStaff = cursor.staffIdx
+      cursor.rewind(Cursor.SELECTION_END)
+      if (cursor.tick === 0) {
+        // this happens when the selection includes
+        // the last measure of the score.
+        // rewind(Cursor.SELECTION_END)) goes behind the last segment
+        // (where there's none) and sets tick=0
+        endTick = curScore.lastSegment.tick + 1
+      }
+      else
+        endTick = cursor.tick
+      endStaff = cursor.staffIdx
+      }
     //console.log(curScore.selection.elements.text)
-    
+
     //console.log(Lyrics.Syllabic,Element.BEGIN, Syllabic)
     curScore.startCmd();
-    while (cursor.segment) {
-      
-      //
-      // Check lyrics
-      //
-      var e = cursor.element;
-      if (e) {
-        console.log("type:", e.name, e.element);
-        for (var i = 0; i < e.lyrics.length; i++) {
-          //console.log(e.lyrics[i].text);
+    for (var staff = startStaff; staff <= endStaff; staff++) {
+      for (var voice = 0; voice < 4; voice++) {
+        cursor.rewind(Cursor.SELECTION_START) // sets voice to 0
+        cursor.voice = voice //voice has to be set after goTo
+        cursor.staffIdx = staff
 
-          // Left single quote (exclude words that start with apostrophe)
-          if (e.lyrics[i].syllabic <= 1 // SINGLE or BEGIN syllable, not END or MIDDLE
-              && wordsStartingWithApostrophe.indexOf(e.lyrics[i].text.replace("&quot;",'"').replace(/[,.?¿!¡;:"‘’“”‚„‹›«»–— *†‡()\[\]{}\/`]/g,"").replace(/'$/,"")) == -1) { // exclude common contractions that starts with an apostrophe (omit punctuation when checking against word list) 
-            e.lyrics[i].text = e.lyrics[i].text.replace(/^'/g,"‘");
-            e.lyrics[i].text = e.lyrics[i].text.replace(/(\s|\s&quot;)'/g,"$1‘");
-            e.lyrics[i].text = e.lyrics[i].text.replace(/^&quot;'|^“'/g,"“‘");
+        if (fullScore)
+          cursor.rewind(Cursor.SCORE_START) // if no selection, beginning of score
+
+        while (cursor.segment) {
+          //
+          // Check lyrics
+          //
+          var e = cursor.element;
+          if (e) {
+            //console.log("type:", e.name, e.element);
+            for (var i = 0; i < e.lyrics.length; i++) {
+              //console.log(e.lyrics[i].syllabic);
+              e.lyrics[i].text = changeQuotes(e.lyrics[i].text, e.lyrics[i].syllabic)
+            }
           }
-          
-          // Right single quote or normal apostrophe
-          e.lyrics[i].text = e.lyrics[i].text.replace(/'/g,"’");
-          
-          // Left double quote
-          e.lyrics[i].text = e.lyrics[i].text.replace(/^&quot;/g,"“");
-          e.lyrics[i].text = e.lyrics[i].text.replace(/(\s‘?)&quot;/g,"$1“");
-          e.lyrics[i].text = e.lyrics[i].text.replace(/^'&quot;|^‘&quot;/g,"‘“");
-          
-          // Right double quote
-          e.lyrics[i].text = e.lyrics[i].text.replace(/&quot;/g,"”");
-        }
-      }
-      //
-      // Check "annotations"
-      //
-      
-      for (var i = 0; i < cursor.segment.annotations.length; i++) {
-        var a = cursor.segment.annotations[i];
-        //console.log(a.name,a.type,a.text)
-        
-        if (a.text) {
-          
-          // Left single quote (exclude words that start with apostrophe)
-          if (wordsStartingWithApostrophe.indexOf(a.text.replace("&quot;",'"').replace(/[,.?¿!¡;:"‘’“”‚„‹›«»–— *†‡()\[\]{}\/`]/g,"").replace(/'$/,"")) == -1) { // exclude common contractions that starts with an apostrophe (omit punctuation when checking against word list) 
-            a.text = a.text.replace(/^'/g,"‘");
-            a.text = a.text.replace(/(\s|\s&quot;)'/g,"$1‘");
-            a.text = a.text.replace(/^&quot;'|^“'/g,"“‘");
+          //
+          // Check "annotations"
+          //
+          for (var i = 0; i < cursor.segment.annotations.length; i++) {
+            var a = cursor.segment.annotations[i];
+            //console.log(a.name, a.type, a.text)
+
+            if (a.text) {
+              a.text = changeQuotes(a.text, 2)
+            }
           }
-          
-          // Right single quote or normal apostrophe
-          a.text = a.text.replace(/'/g,"’");
-          
-          // Left double quote
-          a.text = a.text.replace(/^&quot;/g,"“");
-          a.text = a.text.replace(/(\s‘?)&quot;/g,"$1“");
-          a.text = a.text.replace(/^'&quot;|^‘&quot;/g,"‘“");
-          
-          // Right double quote
-          a.text = a.text.replace(/&quot;/g,"”");
-        }
-      }
-      
-      cursor.next();
-    }
+          cursor.next();
+        } // end while cursor
+      } // end for loop
+    } // end for loop
     curScore.endCmd();
-    //console.log(curScore.title,curScore.scoreName,curScore.composer) // This pulls the metadata under File > Score Properties rather than the text on the page. 
+    //console.log(curScore.title,curScore.scoreName,curScore.composer) // This pulls the metadata under File > Score Properties rather than the text on the page.
     //console.log(curScore.parts[0].staff)
     (typeof(quit) === 'undefined' ? Qt.quit : quit)()
   }

--- a/curlyQuotes.qml
+++ b/curlyQuotes.qml
@@ -4,7 +4,7 @@ import MuseScore 3.0
 MuseScore {
   property variant language : "" //qsTr(" - German")
   menuPath: "Plugins." + qsTr("Curly Quotes") + language 
-  description: "Change apostrophes and double quotes from straight to curly. This plugin affects lyrics text, system text, staff text, expression text, rehearsal marks, instrument changes, and tempo markings."
+  description: "Change apostrophes and double quotes from straight to curly. This plugin affects lyrics and music-attached text (system text, staff text, expression text, rehearsal marks, instrument changes, and tempo markings)."
   version: "1.3"
 
   id: curlyquotes

--- a/curlyQuotes.qml
+++ b/curlyQuotes.qml
@@ -2,99 +2,116 @@ import QtQuick 2.9
 import MuseScore 3.0
 
 MuseScore {
-  menuPath: "Plugins." + qsTr("Curly Quotes")
+  menuPath: "Plugins." + qsTr("Curly Quotes") + language 
   description: "Change apostrophes and double quotes from straight to curly. This plugin affects lyrics text, system text, staff text, expression text, rehearsal marks, instrument changes, and tempo markings."
   version: "1.3"
 
   id: curlyquotes
- 
-  //4.4 title: "Curly Quotes"
+
+  //4.4 title: "Curly Quotes" + language
   Component.onCompleted : {
     if (mscoreMajorVersion >= 4 && mscoreMinorVersion <= 3) {
-       curlyquotes.title = "Curly Quotes";
+       curlyquotes.title = "Curly Quotes" + language;
     }
+  }
+
+  property variant wordsStartingWithApostrophe : ["'bout","'cause","'cept","'em","'fro","'n","'neath","'nother","'pon","'re","'round","'s","'sall","'scuse","'sfar","'sup","'thout","'til","'tis","'twas","'tween","'twere","'ve"]
+
+  function changeQuotes(text, type) {
+    var t = text;
+    // Left single quote (exclude words that start with apostrophe)
+    if (type <= 1 // lyrics SINGLE or BEGIN syllable, not END or MIDDLE
+        && WordsStartingWithApostrophe.indexOf(t.replace("&quot;", '"').replace(/[,.?¿!¡;:"‘’“”‚„‹›«»–— *†‡()\[\]{}\/`]/g, "").replace(/'$/, "")) == -1) { // exclude common contractions that starts with an apostrophe (omit punctuation when checking against word list)
+      t = t.replace(/^'/g,"‘");
+      t = t.replace(/(\s|\s&quot;)'/g, "$1‘");
+      t = t.replace(/^&quot;'|^“'/g, "“‘");
+      }
+
+    // Right single quote or normal apostrophe
+    t = t.replace(/'/g, "’");
+
+    // Left double quote
+    t = t.replace(/^&quot;/g, "“");
+    t = t.replace(/(\s‘?)&quot;/g, "$1“");
+    t = t.replace(/^'&quot;|^‘&quot;/g, "‘“");
+
+    // Right double quote
+    t = t.replace(/&quot;/g, "”");
+
+    return t;
   }
 
   onRun: {
     if (!curScore)
       (typeof(quit) === 'undefined' ? Qt.quit : quit)()
 
-    var wordsStartingWithApostrophe = ["'bout","'cause","'cept","'em","'fro","'n","'neath","'nother","'pon","'re","'round","'s","'sall","'scuse","'sfar","'sup","'thout","'til","'tis","'twas","'tween","'twere","'ve"]
-    
     var cursor = curScore.newCursor();
-    cursor.voice    = 0;
-    cursor.staffIdx = 0;
-    cursor.rewind(Cursor.SCORE_START);
-
+    cursor.rewind(Cursor.SELECTION_START)
+    var startStaff
+    var endStaff
+    var endTick
+    var fullScore = false
+    if (!cursor.segment) { // no selection
+      fullScore = true
+      startStaff = 0 // start with 1st staff
+      endStaff = curScore.nstaves - 1 // and end with last
+    }
+    else {
+      startStaff = cursor.staffIdx
+      cursor.rewind(Cursor.SELECTION_END)
+      if (cursor.tick === 0) {
+        // this happens when the selection includes
+        // the last measure of the score.
+        // rewind(Cursor.SELECTION_END)) goes behind the last segment
+        // (where there's none) and sets tick=0
+        endTick = curScore.lastSegment.tick + 1
+      }
+      else
+        endTick = cursor.tick
+      endStaff = cursor.staffIdx
+      }
     //console.log(curScore.selection.elements.text)
-    
+
     //console.log(Lyrics.Syllabic,Element.BEGIN, Syllabic)
     curScore.startCmd();
-    while (cursor.segment) {
-      
-      //
-      // Check lyrics
-      //
-      var e = cursor.element;
-      if (e) {
-        console.log("type:", e.name, e.element);
-        for (var i = 0; i < e.lyrics.length; i++) {
-          //console.log(e.lyrics[i].text);
+    for (var staff = startStaff; staff <= endStaff; staff++) {
+      for (var voice = 0; voice < 4; voice++) {
+        cursor.rewind(Cursor.SELECTION_START) // sets voice to 0
+        cursor.voice = voice //voice has to be set after goTo
+        cursor.staffIdx = staff
 
-          // Left single quote (exclude words that start with apostrophe)
-          if (e.lyrics[i].syllabic <= 1 // SINGLE or BEGIN syllable, not END or MIDDLE
-              && wordsStartingWithApostrophe.indexOf(e.lyrics[i].text.replace("&quot;",'"').replace(/[,.?¿!¡;:"‘’“”‚„‹›«»–— *†‡()\[\]{}\/`]/g,"").replace(/'$/,"")) == -1) { // exclude common contractions that starts with an apostrophe (omit punctuation when checking against word list) 
-            e.lyrics[i].text = e.lyrics[i].text.replace(/^'/g,"‘");
-            e.lyrics[i].text = e.lyrics[i].text.replace(/(\s|\s&quot;)'/g,"$1‘");
-            e.lyrics[i].text = e.lyrics[i].text.replace(/^&quot;'|^“'/g,"“‘");
+        if (fullScore)
+          cursor.rewind(Cursor.SCORE_START) // if no selection, beginning of score
+
+        while (cursor.segment) {
+          //
+          // Check lyrics
+          //
+          var e = cursor.element;
+          if (e) {
+            //console.log("type:", e.name, e.element);
+            for (var i = 0; i < e.lyrics.length; i++) {
+              //console.log(e.lyrics[i].syllabic);
+              e.lyrics[i].text = changeQuotes(e.lyrics[i].text, e.lyrics[i].syllabic)
+            }
           }
-          
-          // Right single quote or normal apostrophe
-          e.lyrics[i].text = e.lyrics[i].text.replace(/'/g,"’");
-          
-          // Left double quote
-          e.lyrics[i].text = e.lyrics[i].text.replace(/^&quot;/g,"“");
-          e.lyrics[i].text = e.lyrics[i].text.replace(/(\s‘?)&quot;/g,"$1“");
-          e.lyrics[i].text = e.lyrics[i].text.replace(/^'&quot;|^‘&quot;/g,"‘“");
-          
-          // Right double quote
-          e.lyrics[i].text = e.lyrics[i].text.replace(/&quot;/g,"”");
-        }
-      }
-      //
-      // Check "annotations"
-      //
-      
-      for (var i = 0; i < cursor.segment.annotations.length; i++) {
-        var a = cursor.segment.annotations[i];
-        //console.log(a.name,a.type,a.text)
-        
-        if (a.text) {
-          
-          // Left single quote (exclude words that start with apostrophe)
-          if (wordsStartingWithApostrophe.indexOf(a.text.replace("&quot;",'"').replace(/[,.?¿!¡;:"‘’“”‚„‹›«»–— *†‡()\[\]{}\/`]/g,"").replace(/'$/,"")) == -1) { // exclude common contractions that starts with an apostrophe (omit punctuation when checking against word list) 
-            a.text = a.text.replace(/^'/g,"‘");
-            a.text = a.text.replace(/(\s|\s&quot;)'/g,"$1‘");
-            a.text = a.text.replace(/^&quot;'|^“'/g,"“‘");
+          //
+          // Check "annotations"
+          //
+          for (var i = 0; i < cursor.segment.annotations.length; i++) {
+            var a = cursor.segment.annotations[i];
+            //console.log(a.name, a.type, a.text)
+
+            if (a.text) {
+              a.text = changeQuotes(a.text, 2)
+            }
           }
-          
-          // Right single quote or normal apostrophe
-          a.text = a.text.replace(/'/g,"’");
-          
-          // Left double quote
-          a.text = a.text.replace(/^&quot;/g,"“");
-          a.text = a.text.replace(/(\s‘?)&quot;/g,"$1“");
-          a.text = a.text.replace(/^'&quot;|^‘&quot;/g,"‘“");
-          
-          // Right double quote
-          a.text = a.text.replace(/&quot;/g,"”");
-        }
-      }
-      
-      cursor.next();
-    }
+          cursor.next();
+        } // end while cursor
+      } // end for loop
+    } // end for loop
     curScore.endCmd();
-    //console.log(curScore.title,curScore.scoreName,curScore.composer) // This pulls the metadata under File > Score Properties rather than the text on the page. 
+    //console.log(curScore.title,curScore.scoreName,curScore.composer) // This pulls the metadata under File > Score Properties rather than the text on the page.
     //console.log(curScore.parts[0].staff)
     (typeof(quit) === 'undefined' ? Qt.quit : quit)()
   }

--- a/curlyQuotes.qml
+++ b/curlyQuotes.qml
@@ -3,8 +3,8 @@ import MuseScore 3.0
 
 MuseScore {
   menuPath: "Plugins." + qsTr("Curly Quotes")
-  description: "Change apostrophes and double quotes from straight to curly. This plugin can only affect lyric text."
-  version: "1.2"
+  description: "Change apostrophes and double quotes from straight to curly. This plugin affects lyrics text, system text, staff text, expression text, rehearsal marks, instrument changes, and tempo markings."
+  version: "1.3"
 
   id: curlyquotes
  
@@ -29,6 +29,7 @@ MuseScore {
     //console.log(curScore.selection.elements.text)
     
     //console.log(Lyrics.Syllabic,Element.BEGIN, Syllabic)
+    curScore.startCmd();
     while (cursor.segment) {
       
       //
@@ -92,6 +93,7 @@ MuseScore {
       
       cursor.next();
     }
+    curScore.endCmd();
     //console.log(curScore.title,curScore.scoreName,curScore.composer) // This pulls the metadata under File > Score Properties rather than the text on the page. 
     //console.log(curScore.parts[0].staff)
     (typeof(quit) === 'undefined' ? Qt.quit : quit)()


### PR DESCRIPTION
* Add changes made to the undo stack, esp. needed for Mu4 (so the changes actually show directly)
* Make the plugin work on all staves and voices (not just on top staff and voice 1) and factoring out the method doing the actual change
* Embed and add  a German version, enabled by (copying/renaming the plugin file and) changing the `language` to end with "German" (and appending that to the `//4.4 title:` too) so the 2 version have very little difference, just 2 lines.
   Should make it easy to extend this for other languages, like those using guillements «...» and ‹...› or even CJK brackets「⋯」and 『⋯』(see also https://en.wikipedia.org/wiki/Quotation_mark#Summary_table).